### PR TITLE
added options

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -3,34 +3,63 @@ var path = require('path');
 var marked = require('marked');
 var eighty = require('eighty');
 var cardinal = require('cardinal');
+var xtend = require('xtend');
 var color = require('./color');
+
+var defaultOptions = {
+    collapseNewlines: true,
+    space: '',
+    hrStart: '',
+    hrEnd: '',
+    headingStart: '\n',
+    headingEnd: '\n\n',
+    headingIndentChar: '#',
+    codeStart: '\n',
+    codeEnd: '\n\n',
+    codePad: '    ',
+    blockquoteStart: '\n',
+    blockquoteEnd: '\n\n',
+    blockquoteColor: 'blockquote',
+    blockquotePad: '  > ',
+    blockquotePadColor: 'syntax',
+    listStart: '\n',
+    listEnd: '\n',
+    listItemStart: '',
+    listItemEnd: '\n',
+    listItemColor: 'ul',
+    listItemPad: '  * ',
+    listItemPadColor: 'syntax',
+    paragraphStart: '',
+    paragraphEnd: '\n'
+};
 
 var tokens;
 var token;
 var blockDepth = 0;
 
-function processToken() {
+function processToken(options) {
     var type = token.type;
     var text = token.text;
+    var content;
 
     switch (type) {
         case 'space': {
-            return '';
+            return options.space;
         }
         case 'hr': {
-            return color(eighty.hr(), type) + '\n';
+            return options.hrStart + color(eighty.hr(), type) + options.hrEnd;
         }
         case 'heading': {
             var syntaxFlag = color(
-                Array(token.depth + 1).join('#'),
-                "syntax"
+                Array(token.depth + 1).join(options.headingIndentChar),
+                'syntax'
             );
-            var content = color(text, type);
+            content = color(text, type);
 
-            return '\n' + syntaxFlag + ' ' + content + '\n\n';
+            return options.headingStart + syntaxFlag + ' ' + content + options.headingEnd;
         }
         case 'code': {
-            var content = '';
+            content = '';
 
             try {
                 content = cardinal.highlight(text);
@@ -40,61 +69,61 @@ function processToken() {
             }
             
             content = blockFormat(content, {
-                pad_str: '    '
+                pad_str: options.codePad
             });
 
-            return '\n' + content + '\n\n';
+            return options.codeStart + content + options.codeEnd;
         }
         case 'table': {
             // TODO
         }
         case 'blockquote_start': {
-            var content = '';
+            content = '';
             blockDepth++;
 
             while (next().type !== 'blockquote_end') {
-                content += processToken();
+                content += processToken(options);
             }
             content = blockFormat(content, {
-                block_color: 'blockquote',
-                pad_str: '  > ',
-                pad_color: 'syntax'
+                block_color: options.blockquoteColor,
+                pad_str: options.blockquotePad,
+                pad_color: options.blockquotePadColor
             });
 
             blockDepth--;
-            return '\n' + content + '\n\n';
+            return options.blockquoteStart + content + options.blockquoteEnd;
         }
         case 'list_start': {
-            var content = '';
+            content = '';
 
             while (next().type !== 'list_end') {
-                content += processToken();
+                content += processToken(options);
             }
 
-            return '\n' + content + '\n';
+            return options.listStart + content + options.listEnd;
         }
         case 'list_item_start': {
-            var content = '';
+            content = '';
 
             while (next().type !== 'list_item_end') {
                 if (type === 'text') {
                     content += text;
                 } else {
-                    content += processToken();
+                    content += processToken(options);
                 }
             }
             content = blockFormat(content, {
-                block_color: 'ul',
-                pad_str: '  * ',
-                pad_color: 'syntax'
+                block_color: options.listItemColor,
+                pad_str: options.listItemPad,
+                pad_color: options.listItemPadColor
             });
-            return content + '\n';
+            return options.listItemStart + content + options.listItemEnd;
         }
         case 'paragraph': {
             if (blockDepth > 0) {
                 return text;
             }
-            return color(text, type) + '\n';
+            return options.paragraphStart + color(text, type) + options.paragraphEnd;
         }
         default: {
             if (text) {
@@ -110,7 +139,6 @@ function next() {
 
 function blockFormat(src, opts) {
     opts = opts || {};
-
     var lines = src.split('\n');
     var padStr = opts.pad_str || '';
     var padColor = opts.pad_color || opts.block_color;
@@ -130,16 +158,20 @@ function blockFormat(src, opts) {
     return retLines.join('\n');
 }
 
-exports.parse = function(text) {
+exports.parse = function(text, options) {
     tokens = marked.lexer(text);
+    options = xtend(defaultOptions, options);
 
     var outputArr = [];
     var output;
 
     while (next()) {
-        outputArr.push(processToken());
+        outputArr.push(processToken(options));
     }
-    output = outputArr.join('').replace(/\n\n\n/g, '\n\n');
+
+    if (options.collapseNewlines) {
+        output = outputArr.join('').replace(/\n\n\n/g, '\n\n');
+    }
 
     tokens = null;
     token = null;
@@ -147,13 +179,13 @@ exports.parse = function(text) {
     return output;
 }
 
-exports.parseFile = function(file) {
+exports.parseFile = function(file, options) {
     var filePath = path.resolve(__dirname, file);
     var ret = '';
     
     try {
         var text = fs.readFileSync(filePath).toString();
-        ret = exports.parse(text);
+        ret = exports.parse(text, options);
     }
     catch (e) {
         throw e;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "cardinal": "0.3.2",
         "eighty": "0.0.1",
         "marked": "0.2.8",
-        "nopt": "2.1.1"
+        "nopt": "2.1.1",
+        "xtend": "~2.1.1"
     },
     "keywords": [
         "markdown",


### PR DESCRIPTION
Hi, we're trying to migrate the [nodeschool](http://nodeschool.io) workshops to use Markdown formatting on the commandline with msee but would like to be able to adjust a bunch of formatting options.

This PR adds an options object that lets us change some things (in particular I'd like to have more whitespace around paragraphs).

Cheers!

/cc @timoxley does this do enough for you too?
