### PR TITLE
wrap paragraphs to fit into the screen

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -29,7 +29,9 @@ var defaultOptions = {
     listItemPad: '  * ',
     listItemPadColor: 'syntax',
     paragraphStart: '',
-    paragraphEnd: '\n'
+    paragraphEnd: '\n',
+    paragraphPad: '  ',
+    width: process.stdout.columns - 2
 };
 
 var tokens;
@@ -149,7 +151,7 @@ function processToken(options) {
             return options.space;
         }
         case 'hr': {
-            var hrStr = new Array(80).join('-') + '\n';
+            var hrStr = new Array(options.width).join('-') + '\n';
             return options.hrStart + color(hrStr, type) + options.hrEnd;
         }
         case 'heading': {
@@ -191,7 +193,8 @@ function processToken(options) {
             content = blockFormat(content, {
                 block_color: options.blockquoteColor,
                 pad_str: options.blockquotePad,
-                pad_color: options.blockquotePadColor
+                pad_color: options.blockquotePadColor,
+                width: options.width
             });
 
             blockDepth--;
@@ -228,7 +231,12 @@ function processToken(options) {
                 return text;
             }
             text = processInline(text);
-            return options.paragraphStart + color(text, type) + options.paragraphEnd;
+            return options.paragraphStart +
+              wordWrap(text, {
+                pad_str: options.paragraphPad,
+                width: options.width
+            }) +
+            options.paragraphEnd;
         }
         default: {
             if (text) {
@@ -243,8 +251,6 @@ function next() {
 }
 
 function blockFormat(src, opts) {
-    opts = opts || {};
-
     var lines = src.split('\n');
     var padStr = opts.pad_str || '';
     var padColor = opts.pad_color || opts.block_color;
@@ -262,6 +268,44 @@ function blockFormat(src, opts) {
     });
 
     return retLines.join('\n');
+  
+}
+
+function wordWrap(src, opts) {
+    opts = opts || {};
+
+    function colorLine (str) {
+        if(opts.block_color) {
+            return color(str, opts.block_color)
+        }
+        return str
+    }
+
+    var padStr = opts.pad_str || ''
+    var width = opts.width || 80
+    var padLength = padStr.length
+
+    if (opts.pad_color) {
+        padStr = color(padStr, opts.pad_color);
+    }
+
+    return src.split(/\n\n+/).map(function (line) {
+        var words = line.trim().split(/\s+/)
+        var lines = '', line = '', length = 0
+
+        while(words.length) {
+            var word = words.shift()
+            if(length + word.length + 1 > width) {
+                lines += colorLine(line) + '\n'
+                line = ''
+                length = 0
+            }
+            length += word.length + (length ? 1 : padLength)
+            line += (line ? ' ' + word : padStr + word)
+        }
+
+        return lines + line
+    }).join('\n\n')
 }
 
 exports.parse = function(text, options) {


### PR DESCRIPTION
this patch wraps paragraphs and block quotes to fit within the terminal.
(similar to how man pages do it) it also indents paragraphs by 2 chars,
This makes markdown much more readable, especially if someone has not wrapped
the source nicely.

I also wanted to do this for lists, but it wasn't that easy to add to your
list processing code, so I thought I'd run this by you first.

my main case is to make nodeschool problems more readable (/cc @rvagg)