### PR TITLE
add support for tables.

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -4,6 +4,7 @@ var marked = require('marked');
 var cardinal = require('cardinal');
 var xtend = require('xtend');
 var color = require('./color');
+var table = require('text-table');
 
 var defaultOptions = {
     collapseNewlines: true,
@@ -29,7 +30,10 @@ var defaultOptions = {
     listItemPad: '  * ',
     listItemPadColor: 'syntax',
     paragraphStart: '',
-    paragraphEnd: '\n'
+    paragraphEnd: '\n',
+    tableStart: '\n',
+    tableSeparator: ' ',
+    tableEnd: '\n\n'
 };
 
 var tokens;
@@ -171,7 +175,7 @@ function processToken(options) {
             catch (e) {
                 content = color(text, type);
             }
-            
+
             content = blockFormat(content, {
                 pad_str: options.codePad
             });
@@ -179,7 +183,8 @@ function processToken(options) {
             return options.codeStart + content + options.codeEnd;
         }
         case 'table': {
-            // TODO
+            content = tableFormat(token, options);
+            return options.tableStart + content + options.tableEnd;
         }
         case 'blockquote_start': {
             content = '';
@@ -264,6 +269,29 @@ function blockFormat(src, opts) {
     return retLines.join('\n');
 }
 
+function tableFormat (token, options) {
+    var aligns = token.align.map(function(a){ return (a===null)? 'l' : a[0] });
+    var rows = token.cells.map(function(row){ return row.map(processInline) });
+    rows.unshift(token.header.map(function(){ return '--' }));
+    rows.unshift(token.header.map(function(s){ return processInline('**'+s+'**') }));
+    return table(rows, {
+        align: aligns,
+        stringLength: ansiLength,
+        hsep: options.tableSeparator
+    });
+}
+
+/**
+ * Trim formatting from string
+ * @see https://github.com/medikoo/cli-color/blob/master/trim.js
+ */
+
+function ansiLength (str) {
+    var r = new RegExp('\x1b(?:\\[(?:\\d+[ABCDEFGJKSTm]|\\d+;\\d+[Hfm]|' +
+    '\\d+;\\d+;\\d+m|6n|s|u|\\?25[lh])|\\w)', 'g');
+    return str.replace(r, '').length;
+}
+
 exports.parse = function(text, options) {
     tokens = marked.lexer(text);
     inline = new marked.InlineLexer(tokens.links);
@@ -289,7 +317,7 @@ exports.parse = function(text, options) {
 exports.parseFile = function(file, options) {
     var filePath = path.resolve(__dirname, file);
     var ret = '';
-    
+
     try {
         var text = fs.readFileSync(filePath).toString();
         ret = exports.parse(text, options);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "cardinal": "~0.4.3",
         "marked": "~0.3.0",
         "nopt": "~2.1.1",
+        "text-table": "^0.2.0",
         "xtend": "~2.1.1"
     },
     "keywords": [


### PR DESCRIPTION
I've added support for tables using [substack's text-table](https://github.com/substack/text-table).

Automatic widths, left/center/right alignment, and inline styles all work:

![screen shot 2015-03-29 at 2 30 43 pm](https://cloud.githubusercontent.com/assets/679312/6887854/887b083a-d620-11e4-9625-5f06163b924e.png)
