### PR TITLE
Update cardinal to latest version for ES6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,32 +1,32 @@
 {
-    "name": "msee",
-    "version": "0.1.1",
-    "description": "Msee is a command-line tool to read Markdown file in your terminal, and it's a library help your command-line software to output readable markdown content.",
-    "main": "./lib/msee.js",
-    "bin": "./bin/msee",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/firede/msee.git"
-    },
-    "dependencies": {
-        "chalk": "~0.4.0",
-        "cardinal": "~0.4.3",
-        "marked": "~0.3.0",
-        "nopt": "~2.1.1",
-        "xtend": "~2.1.1"
-    },
-    "keywords": [
-        "markdown",
-        "terminal",
-        "reader",
-        "console",
-        "shell",
-        "colors",
-        "highlight"
-    ],
-    "author": "Firede <firede@firede.us>",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/firede/msee/issues"
-    }
+  "name": "msee",
+  "version": "0.1.1",
+  "description": "Msee is a command-line tool to read Markdown file in your terminal, and it's a library help your command-line software to output readable markdown content.",
+  "main": "./lib/msee.js",
+  "bin": "./bin/msee",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/firede/msee.git"
+  },
+  "dependencies": {
+    "cardinal": "^0.5.0",
+    "chalk": "~0.4.0",
+    "marked": "~0.3.0",
+    "nopt": "~2.1.1",
+    "xtend": "~2.1.1"
+  },
+  "keywords": [
+    "markdown",
+    "terminal",
+    "reader",
+    "console",
+    "shell",
+    "colors",
+    "highlight"
+  ],
+  "author": "Firede <firede@firede.us>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/firede/msee/issues"
+  }
 }


### PR DESCRIPTION
A very small PR. Cardinal supports syntax highlighting of ES6 JavaScript syntax since its latest version.

Before:
<img width="724" alt="screen shot 2015-10-14 at 09 31 28" src="https://cloud.githubusercontent.com/assets/877585/10477471/b06913d2-7256-11e5-8f11-e5189427256c.png">

After:
<img width="762" alt="screen shot 2015-10-14 at 09 31 36" src="https://cloud.githubusercontent.com/assets/877585/10477474/b68629bc-7256-11e5-905d-7e63b42f3a63.png">

