### PR TITLE
Language type based indent

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -173,7 +173,7 @@ function processToken(options) {
             }
             
             content = blockFormat(content, {
-                pad_str: options.codePad
+                pad_str: options.codePad.lang ? (options.codePad.lang[token.lang] || options.defaultCodePad) : options.codePad
             });
 
             return options.codeStart + content + options.codeEnd;

--- a/lib/msee.js
+++ b/lib/msee.js
@@ -173,7 +173,7 @@ function processToken(options) {
             }
             
             content = blockFormat(content, {
-                pad_str: options.codePad.lang ? (options.codePad.lang[token.lang] || options.defaultCodePad) : options.codePad
+                pad_str: options.codePad.lang ? (typeof options.codePad.lang[token.lang] === 'string' ? options.codePad.lang[token.lang] : options.defaultCodePad) : options.codePad
             });
 
             return options.codeStart + content + options.codeEnd;


### PR DESCRIPTION
I needed to be able to have indentations that are different for different code types. It seems like an ok feature?