### PR TITLE
Synchronised  "no-color" option and codeTheme

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -5,6 +5,7 @@ var cardinal = require('cardinal');
 var xtend = require('xtend');
 var color = require('./color');
 var table = require('text-table');
+var chalk = require('chalk');
 
 var defaultOptions = {
     collapseNewlines: true,
@@ -18,6 +19,7 @@ var defaultOptions = {
     codeStart: '\n',
     codeEnd: '\n\n',
     codePad: '    ',
+    codeTheme: undefined,
     blockquoteStart: '\n',
     blockquoteEnd: '\n\n',
     blockquoteColor: 'blockquote',
@@ -172,7 +174,11 @@ function processToken(options) {
             content = '';
 
             try {
-                content = cardinal.highlight(text);
+                content = cardinal.highlight(text, {
+                    theme: chalk.supportsColor
+                            ? options.codeTheme
+                            : require('cardinal/themes/empty')
+                });
             }
             catch (e) {
                 content = color(text, type);


### PR DESCRIPTION
[chalk](https://github.com/chalk/chalk) automatically detects if a `--no-color` option is added to the node system and disables coloring. I used `chalk.supportsColor` to specify the color settings for `cardinal`. Since I had to specify the theme I also added it as a general option to `msee` (`opts.codeTheme`).