### PR TITLE
Direct output with raw option

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -173,6 +173,10 @@ function processToken(options) {
         case 'code': {
             content = '';
 
+            if (token.lang === 'raw') {
+                return text + '\n';
+            }
+
             try {
                 content = cardinal.highlight(text, {
                     theme: chalk.supportsColor


### PR DESCRIPTION
I have the use-case at nodeschool that I need to render text formatted by something else than msee mixed with markdown code.

```
<markdown>
<raw text>
<markdown>
```

Now I also have the problem that I want the content to be rendered optionally as html instead of for-terminal with `msee`. This means that formatting should take place after the content combination. 

I of course could do something like this:
```
combine(
  msee(markdownA), 
  raw,
  msee(markdownB)
)
```
But that makes the structure quite a bit complicated (all the parts need to be able to deal with complex code). I thought it might be an easier option to have a `raw` code type that is directly rendered to-terminal. This way I can combine content like this

```JavaScript
stream.append(markdownA)
stream.append("```raw\n" + raw + "```\n")
stream.append(markdownB)
stream.pipe(msee)
```

which just seems a lot more elegant. Do you think it would be okay to offer this option? 

PS.: I was also considering a `ansi` code-keyword instead of `raw`, maybe a better option?