### PR TITLE
Added function support similar to `codePad` for heading

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -16,6 +16,9 @@ var defaultOptions = {
     headingStart: '\n',
     headingEnd: '\n\n',
     headingIndentChar: '#',
+    headingIndent: function (token) {
+        return Array(token.depth + 1).join(this.headingIndentChar)
+    },
     codeStart: '\n',
     codeEnd: '\n\n',
     codePad: '    ',
@@ -167,7 +170,7 @@ function processToken(options) {
         }
         case 'heading': {
             var syntaxFlag = color(
-                Array(token.depth + 1).join(options.headingIndentChar),
+                options.headingIndent(token),
                 'syntax'
             );
             text = processInline(text);


### PR DESCRIPTION
It seemed appropriate that the header implementation is a little more flexible so I added a function-template support. This is similar to `getOption` for `codePad` but due to the nature of headings I thought this implementation might be a little more elegant.