### PR TITLE
Blockformat of paragraphs

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -34,6 +34,7 @@ var defaultOptions = {
     listItemPadColor: 'syntax',
     paragraphStart: '',
     paragraphEnd: '\n',
+    paragraphIndent: ' ',
     width: process.stdout.columns || 80,
     tableStart: '\n',
     tableSeparator: ' ',
@@ -248,8 +249,15 @@ function processToken(options) {
             if (blockDepth > 0) {
                 return text;
             }
-            text = processInline(text);
-            return options.paragraphStart + color(text, type) + options.paragraphEnd;
+            text = blockFormat(
+                processInline(text),
+                {
+                    block_color: type,
+                    pad_str: options.paragraphPad,
+                    pad_color: options.paragraphPadColor
+                }
+            );
+            return options.paragraphStart + text + options.paragraphEnd;
         }
         default: {
             if (text) {


### PR DESCRIPTION
Most of the functions in paragraphs are analogous to the other blocks so I used `blockFormat` there as well (precursor to new version of wrapping)