### PR TITLE
Used more sensitive color defaults both for better readability

### DIFF
--- a/lib/color.js
+++ b/lib/color.js
@@ -4,7 +4,7 @@ var colorBrushes = {
     "syntax": chalk.grey,
     "heading": chalk.cyan.bold,
     "hr": chalk.grey,
-    "code": chalk.yellow,
+    "code": chalk.grey,
     "blockquote": chalk.blue,
     "bold": chalk.bold,
     "link": chalk.blue,

--- a/lib/msee.js
+++ b/lib/msee.js
@@ -19,7 +19,7 @@ var defaultOptions = {
     codeStart: '\n',
     codeEnd: '\n\n',
     codePad: '    ',
-    codeTheme: undefined,
+    codeTheme: require('./syntaxColor'),
     blockquoteStart: '\n',
     blockquoteEnd: '\n\n',
     blockquoteColor: 'blockquote',

--- a/lib/msee.js
+++ b/lib/msee.js
@@ -6,6 +6,7 @@ var xtend = require('xtend');
 var color = require('./color');
 var table = require('text-table');
 var chalk = require('chalk');
+var os = require('os');
 
 var defaultOptions = {
     collapseNewlines: true,
@@ -19,7 +20,7 @@ var defaultOptions = {
     codeStart: '\n',
     codeEnd: '\n\n',
     codePad: '    ',
-    codeTheme: require('./syntaxColor'),
+    codeTheme: os.platform() === 'win32' ? require('./syntaxColor_win') : require('./syntaxColor'),
     blockquoteStart: '\n',
     blockquoteEnd: '\n\n',
     blockquoteColor: 'blockquote',

--- a/lib/syntaxColor.js
+++ b/lib/syntaxColor.js
@@ -1,0 +1,157 @@
+var colors = require('ansicolors');
+
+// Change the below definitions in order to tweak the color theme.
+module.exports = {
+
+    'Boolean': {
+      'true'   :  undefined
+    , 'false'  :  undefined
+    , _default :  colors.red
+    }
+
+  , 'Identifier': {
+      'undefined' :  colors.magenta
+    , 'self'      :  colors.red
+    , 'console'   :  colors.blue
+    , 'log'       :  colors.blue
+    , 'warn'      :  colors.red
+    , 'error'     :  colors.red
+    , _default    :  colors.black
+    }
+
+  , 'Null': {
+      _default: colors.magenta
+    }
+
+  , 'Numeric': {
+      _default: colors.blue
+    }
+
+  , 'String': {
+      _default: function (s, info) {
+        var nextToken = info.tokens[info.tokenIndex + 1];
+
+        // show keys of object literals and json in different color
+        return (nextToken && nextToken.type === 'Punctuator' && nextToken.value === ':') 
+          ? colors.blue(s)
+          : colors.green(s);
+      }
+    }
+
+  , 'Keyword': {
+      'break'       :  undefined
+
+    , 'case'        :  undefined
+    , 'catch'       :  colors.cyan
+    , 'class'       :  undefined
+    , 'const'       :  undefined
+    , 'continue'    :  undefined
+
+    , 'debugger'    :  undefined
+    , 'default'     :  undefined
+    , 'delete'      :  colors.red
+    , 'do'          :  undefined
+
+    , 'else'        :  undefined
+    , 'export'      :  undefined
+    , 'extends'     :  undefined
+
+    , 'finally'     :  colors.cyan
+    , 'for'         :  undefined
+    , 'function'    :  colors.red
+
+    , 'if'          :  undefined
+    , 'import'      :  undefined
+    , 'in'          :  undefined
+    , 'instanceof'  :  undefined
+    , 'let'         :  undefined
+    , 'new'         :  colors.yellow
+    , 'return'      :  colors.yellow
+    , 'static'      :  undefined
+    , 'super'       :  undefined
+    , 'switch'      :  undefined
+
+    , 'this'        :  colors.red
+    , 'throw'       :  undefined
+    , 'try'         :  colors.cyan
+    , 'typeof'      :  undefined
+
+    , 'var'         :  colors.green
+    , 'void'        :  undefined
+
+    , 'while'       :  undefined
+    , 'with'        :  undefined
+    , 'yield'       :  undefined
+    , _default      :  colors.blue
+  }
+  , 'Punctuator': {
+      ';': colors.black
+    , '.': colors.black  
+    , ',': colors.black  
+
+    , '{': colors.yellow
+    , '}': colors.yellow
+    , '(': colors.black  
+    , ')': colors.black  
+    , '[': colors.yellow
+    , ']': colors.yellow
+
+    , '<': undefined
+    , '>': undefined
+    , '+': undefined
+    , '-': undefined
+    , '*': undefined
+    , '%': undefined
+    , '&': undefined
+    , '|': undefined
+    , '^': undefined
+    , '!': undefined
+    , '~': undefined
+    , '?': undefined
+    , ':': undefined
+    , '=': colors.red
+
+    , '<=': undefined
+    , '>=': undefined
+    , '==': undefined
+    , '!=': undefined
+    , '++': undefined
+    , '--': undefined
+    , '<<': undefined
+    , '>>': undefined
+    , '&&': undefined
+    , '||': undefined
+    , '+=': undefined
+    , '-=': undefined
+    , '*=': undefined
+    , '%=': undefined
+    , '&=': undefined
+    , '|=': undefined
+    , '^=': undefined
+    , '/=': undefined
+    , '=>': undefined
+
+    , '===': undefined
+    , '!==': undefined
+    , '>>>': undefined
+    , '<<=': undefined
+    , '>>=': undefined
+    , '...': undefined
+    
+    , '>>>=': undefined
+
+    , _default: colors.yellow
+  }
+
+    // line comment
+  , Line: {
+     _default: colors.white
+    }
+
+    /* block comment */
+  , Block: {
+     _default: colors.white
+    }
+
+  , _default: undefined
+};

--- a/lib/syntaxColor.js
+++ b/lib/syntaxColor.js
@@ -16,7 +16,7 @@ module.exports = {
     , 'log'       :  colors.blue
     , 'warn'      :  colors.red
     , 'error'     :  colors.red
-    , _default    :  colors.black
+    , _default    :  undefined
     }
 
   , 'Null': {
@@ -82,19 +82,19 @@ module.exports = {
     , 'while'       :  undefined
     , 'with'        :  undefined
     , 'yield'       :  undefined
-    , _default      :  colors.black
+    , _default      :  undefined
   }
   , 'Punctuator': {
-      ';': colors.black
-    , '.': colors.black  
-    , ',': colors.black  
+      ';': undefined
+    , '.': undefined  
+    , ',': undefined  
 
-    , '{': colors.black
-    , '}': colors.black
-    , '(': colors.black  
-    , ')': colors.black  
-    , '[': colors.black
-    , ']': colors.black
+    , '{': undefined
+    , '}': undefined
+    , '(': undefined  
+    , ')': undefined  
+    , '[': undefined
+    , ']': undefined
 
     , '<': undefined
     , '>': undefined
@@ -153,5 +153,5 @@ module.exports = {
      _default: colors.white
     }
 
-  , _default: undefined
+  , _default: colors.green
 };

--- a/lib/syntaxColor.js
+++ b/lib/syntaxColor.js
@@ -49,7 +49,7 @@ module.exports = {
 
     , 'debugger'    :  undefined
     , 'default'     :  undefined
-    , 'delete'      :  colors.red
+    , 'delete'      :  colors.cyan
     , 'do'          :  undefined
 
     , 'else'        :  undefined
@@ -58,20 +58,20 @@ module.exports = {
 
     , 'finally'     :  colors.cyan
     , 'for'         :  undefined
-    , 'function'    :  colors.red
+    , 'function'    :  colors.magenta
 
     , 'if'          :  undefined
     , 'import'      :  undefined
     , 'in'          :  undefined
     , 'instanceof'  :  undefined
     , 'let'         :  undefined
-    , 'new'         :  colors.yellow
-    , 'return'      :  colors.yellow
+    , 'new'         :  colors.magenta
+    , 'return'      :  colors.magenta
     , 'static'      :  undefined
     , 'super'       :  undefined
     , 'switch'      :  undefined
 
-    , 'this'        :  colors.red
+    , 'this'        :  colors.blue
     , 'throw'       :  undefined
     , 'try'         :  colors.cyan
     , 'typeof'      :  undefined
@@ -82,19 +82,19 @@ module.exports = {
     , 'while'       :  undefined
     , 'with'        :  undefined
     , 'yield'       :  undefined
-    , _default      :  colors.blue
+    , _default      :  colors.black
   }
   , 'Punctuator': {
       ';': colors.black
     , '.': colors.black  
     , ',': colors.black  
 
-    , '{': colors.yellow
-    , '}': colors.yellow
+    , '{': colors.black
+    , '}': colors.black
     , '(': colors.black  
     , ')': colors.black  
-    , '[': colors.yellow
-    , ']': colors.yellow
+    , '[': colors.black
+    , ']': colors.black
 
     , '<': undefined
     , '>': undefined
@@ -140,7 +140,7 @@ module.exports = {
     
     , '>>>=': undefined
 
-    , _default: colors.yellow
+    , _default: colors.red
   }
 
     // line comment

--- a/lib/syntaxColor_win.js
+++ b/lib/syntaxColor_win.js
@@ -1,0 +1,157 @@
+var colors = require('ansicolors');
+
+// Change the below definitions in order to tweak the color theme.
+module.exports = {
+
+    'Boolean': {
+      'true'   :  undefined
+    , 'false'  :  undefined
+    , _default :  colors.brightYellow
+    }
+
+  , 'Identifier': {
+      'undefined' :  colors.brightMagenta
+    , 'self'      :  colors.brightRed
+    , 'console'   :  undefined
+    , 'log'       :  colors.brightYellow
+    , 'warn'      :  colors.brightYellow
+    , 'error'     :  colors.brightYellow
+    , _default    :  undefined
+    }
+
+  , 'Null': {
+      _default: colors.brightMagenta
+    }
+
+  , 'Numeric': {
+      _default: colors.brightBlue
+    }
+
+  , 'String': {
+      _default: function (s, info) {
+        var nextToken = info.tokens[info.tokenIndex + 1];
+
+        // show keys of object literals and json in different color
+        return (nextToken && nextToken.type === 'Punctuator' && nextToken.value === ':') 
+          ? colors.brightBlue(s)
+          : colors.brightGreen(s);
+      }
+    }
+
+  , 'Keyword': {
+      'break'       :  undefined
+
+    , 'case'        :  undefined
+    , 'catch'       :  undefined
+    , 'class'       :  undefined
+    , 'const'       :  undefined
+    , 'continue'    :  undefined
+
+    , 'debugger'    :  undefined
+    , 'default'     :  undefined
+    , 'delete'      :  undefined
+    , 'do'          :  undefined
+
+    , 'else'        :  undefined
+    , 'export'      :  undefined
+    , 'extends'     :  undefined
+
+    , 'finally'     :  undefined
+    , 'for'         :  undefined
+    , 'function'    :  colors.brightMagenta
+
+    , 'if'          :  undefined
+    , 'import'      :  undefined
+    , 'in'          :  undefined
+    , 'instanceof'  :  colors.brightMagenta
+    , 'let'         :  undefined
+    , 'new'         :  colors.brightRed
+    , 'return'      :  colors.brigntMagenta
+    , 'static'      :  undefined
+    , 'super'       :  undefined
+    , 'switch'      :  undefined
+
+    , 'this'        :  undefined
+    , 'throw'       :  undefined
+    , 'try'         :  undefined
+    , 'typeof'      :  undefined
+
+    , 'var'         :  colors.brightCyan
+    , 'void'        :  undefined
+
+    , 'while'       :  undefined
+    , 'with'        :  undefined
+    , 'yield'       :  undefined
+    , _default      :  colors.brightCyan
+  }
+  , 'Punctuator': {
+      ';': undefined
+    , '.': undefined  
+    , ',': undefined 
+
+    , '{': undefined
+    , '}': undefined
+    , '(': undefined  
+    , ')': undefined 
+    , '[': undefined
+    , ']': undefined
+
+    , '<': colors.brightMagenta
+    , '>': colors.brightMagenta
+    , '+': colors.brightMagenta
+    , '-': colors.brightMagenta
+    , '*': colors.brightMagenta
+    , '%': colors.brightMagenta
+    , '&': colors.brightMagenta
+    , '|': colors.brightMagenta
+    , '^': colors.brightMagenta
+    , '!': colors.brightMagenta
+    , '~': colors.brightMagenta
+    , '?': colors.brightMagenta
+    , ':': undefined
+    , '=': colors.brightMagenta
+
+    , '<=': colors.brighYellow
+    , '>=': colors.brighYellow
+    , '==': colors.brighYellow
+    , '!=': colors.brighYellow
+    , '++': colors.brighYellow
+    , '--': colors.brighYellow
+    , '<<': colors.brighYellow
+    , '>>': colors.brighYellow
+    , '&&': colors.brighYellow
+    , '||': colors.brighYellow
+    , '+=': colors.brighYellow
+    , '-=': colors.brighYellow
+    , '*=': colors.brighYellow
+    , '%=': colors.brighYellow
+    , '&=': colors.brighYellow
+    , '|=': colors.brighYellow
+    , '^=': colors.brighYellow
+    , '/=': colors.brighYellow
+    , '=>': colors.brighYellow
+
+    , '===': colors.brightCyan
+    , '!==': colors.brightCyan
+    , '>>>': colors.brightCyan
+    , '<<=': colors.brightCyan
+    , '>>=': colors.brightCyan
+    , '...': colors.brightCyan
+    
+    , '>>>=': colors.cyan
+
+    , _default: undefined
+  }
+
+    // line comment
+  , Line: {
+     _default: colors.white
+    }
+
+    /* block comment */
+  , Block: {
+     _default: colors.white
+    }
+
+  , _default: undefined
+};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "ansi-regex": "^2.0.0",
+    "ansicolors": "^0.3.2",
     "cardinal": "^0.5.0",
     "chalk": "^1.1.1",
     "marked": "^0.3.5",


### PR DESCRIPTION
At nodeschool we received many complaints that the readability of code has not been very good. This patch takes a few deliberate choices to trade beauty in "good" terminals for readability in "bad" terminals. (Windows users seem to have most problems)