### PR TITLE
Reducing table rendering code by using wcstring

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -312,81 +312,11 @@ function tableFormat (token, options) {
     );
     return table(rows, {
         align: aligns,
-        stringLength: getStringWidth,
+        stringLength: function (str) {
+            return wcstring(str).width()
+        },
         hsep: options.tableSeparator
     });
-}
-
-/**
- * Returns the number of columns required to display the given string.
- * @see https://github.com/nodejs/node/blob/cff7300a578be1b10001f2d967aaedc88aee6402/lib/readline.js#L1345
- */
-function getStringWidth(str) {
-    // Trim formatting from string
-    var rAnsi = require('ansi-regex')();
-    str = str.replace(rAnsi, '');
-
-    var width = 0;
-    for (var i = 0, len = str.length; i < len; i++) {
-        var code = str.codePointAt(i);
-        if (code >= 0x10000) { // surrogates
-            i++;
-        }
-        if (isFullWidthCodePoint(code)) {
-            width += 2;
-        }
-        else {
-            width++;
-        }
-    }
-    return width;
-}
-
-function isFullWidthCodePoint(code) {
-    if (isNaN(code)) {
-        return false;
-    }
-
-    // Code points are derived from:
-    // http://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt
-    if (code >= 0x1100
-        && (
-            // Hangul Jamo
-            code <= 0x115f
-            // LEFT-POINTING ANGLE BRACKET
-            || 0x2329 === code
-            // RIGHT-POINTING ANGLE BRACKET
-            || 0x232a === code
-            // CJK Radicals Supplement .. Enclosed CJK Letters and Months
-            || (0x2e80 <= code && code <= 0x3247 && code !== 0x303f)
-            // Enclosed CJK Letters and Months .. CJK Unified Ideographs Extension A
-            || 0x3250 <= code && code <= 0x4dbf
-            // CJK Unified Ideographs .. Yi Radicals
-            || 0x4e00 <= code && code <= 0xa4c6
-            // Hangul Jamo Extended-A
-            || 0xa960 <= code && code <= 0xa97c
-            // Hangul Syllables
-            || 0xac00 <= code && code <= 0xd7a3
-            // CJK Compatibility Ideographs
-            || 0xf900 <= code && code <= 0xfaff
-            // Vertical Forms
-            || 0xfe10 <= code && code <= 0xfe19
-            // CJK Compatibility Forms .. Small Form Variants
-            || 0xfe30 <= code && code <= 0xfe6b
-            // Halfwidth and Fullwidth Forms
-            || 0xff01 <= code && code <= 0xff60
-            || 0xffe0 <= code && code <= 0xffe6
-            // Kana Supplement
-            || 0x1b000 <= code && code <= 0x1b001
-            // Enclosed Ideographic Supplement
-            || 0x1f200 <= code && code <= 0x1f251
-            // CJK Unified Ideographs Extension B .. Tertiary Ideographic Plane
-            || 0x20000 <= code && code <= 0x3fffd
-        )
-    ) {
-        return true;
-    }
-    return false;
 }
 
 exports.parse = function(text, options) {


### PR DESCRIPTION
The table rendering code of msee had partial code from `wcwidth` which is the same algorithm that powers `wcstring` that is used for wrapping the content. I removed the table code in favor of `wcstring`