### PR TITLE
Added complex padding support

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -31,11 +31,10 @@ var defaultOptions = {
     listItemStart: '',
     listItemEnd: '\n',
     listItemColor: 'ul',
-    listItemPad: '  * ',
+    listItemPad: {first: '  * ', regular: '    '},
     listItemPadColor: 'syntax',
     paragraphStart: '',
     paragraphEnd: '\n\n',
-    paragraphPad: ' ',
     width: process.stdout.columns || 80,
     tableStart: '\n',
     tableSeparator: ' ',
@@ -170,7 +169,7 @@ function processToken(options) {
         case 'heading': {
             text = blockFormat(processInline(text), {
                 block_color: type,
-                pad_str: Array(token.depth + 1).join(options.headingIndentChar) + ' ',
+                pad: Array(token.depth + 1).join(options.headingIndentChar) + ' ',
                 pad_color: 'syntax',
                 width: options.width
             })
@@ -208,7 +207,7 @@ function processToken(options) {
             }
             content = blockFormat(content, {
                 block_color: options.blockquoteColor,
-                pad_str: options.blockquotePad,
+                pad: options.blockquotePad,
                 pad_color: options.blockquotePadColor,
                 width: options.width
             });
@@ -239,7 +238,7 @@ function processToken(options) {
                 processInline(content),
                 {
                     block_color: options.listItemColor,
-                    pad_str: options.listItemPad,
+                    pad: options.listItemPad,
                     pad_color: options.listItemPadColor,
                     width: options.width
                 }
@@ -254,7 +253,7 @@ function processToken(options) {
                 processInline(text),
                 {
                     block_color: type,
-                    pad_str: options.paragraphPad,
+                    pad: options.paragraphPad,
                     pad_color: options.paragraphPadColor,
                     width: options.width
                 }
@@ -276,21 +275,16 @@ function next() {
 function blockFormat(src, opts) {
     opts = opts || {};
 
-    var padStr = opts.pad_str || '';
-    var padColor = opts.pad_color || opts.block_color;
     var retLines = [];
-    var width = opts.width;
-    width -= padStr.length;
 
-    if (padColor) {
-        padStr = color(padStr, padColor);
-    }
-
-    src = wcstring(src).wrap(width);
-
-    return src.replace(/^(.*)$/mg, function (found) {
-        return padStr + color(found, opts.block_color)
+    src = wcstring(src).wrap(opts.width, opts.pad, function (padStr) {
+        if (opts.pad_color) {
+            return color(padStr, opts.pad_color)
+        }
+        return padStr
     });
+
+    return color(src, opts.block_color);
 }
 
 function tableFormat (token, options) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "marked": "^0.3.5",
     "nopt": "^3.0.4",
     "text-table": "^0.2.0",
-    "wcstring": "^1.0.1",
+    "wcstring": "^2.1.0",
     "xtend": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
The current padding only supports padding-left. This PR allows more flexible padding. Namingly: It allows a different padding for the first and the following rows (important for list items) and it allows a right padding. The configuration syntax is compatible (meaning that old configuration should work without change). 