### PR TITLE
Adjust table header borders

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -5,6 +5,7 @@ var cardinal = require('cardinal');
 var xtend = require('xtend');
 var color = require('./color');
 var table = require('text-table');
+var addHeader = require('table-header').add;
 var chalk = require('chalk');
 var wcstring = require('wcstring');
 
@@ -295,23 +296,22 @@ function tableFormat (token, options) {
     var rows = token.cells.map(function (row) {
         return row.map(processInline);
     });
-    rows.unshift(
-        token.header.map(function () {
-            return '--';
-        })
-    );
-    rows.unshift(
-        token.header.map(function (s) {
-            return processInline('**'+s+'**');
-        })
-    );
+    var headers = token.header.map(function (s) {
+        return processInline('**'+s+'**');
+    });
+    addHeader(rows, headers, { stringLength: getStringWidth });
     return table(rows, {
         align: aligns,
-        stringLength: function (str) {
-            return wcstring(str).width()
-        },
+        stringLength: getStringWidth,
         hsep: options.tableSeparator
     });
+}
+
+/**
+ * Returns the number of columns required to display the given string.
+ */
+function getStringWidth(str) {
+  return wcstring(str).width();
 }
 
 exports.parse = function(text, options) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "chalk": "^1.1.1",
     "marked": "^0.3.5",
     "nopt": "^3.0.4",
+    "table-header": "^0.2.2",
     "text-table": "^0.2.0",
     "wcstring": "^2.1.0",
     "xtend": "^4.0.0"


### PR DESCRIPTION
Currently table borders are set statically to the string `--` each. This doesn't look very nice for tables with wider columns.

For example:

```
$ printf 'color|code\n--|--\nred|#ff0000\ngreen|#00ffff\nblue|#0000ff\n' |msee

color code
--    --
red   #ff0000
green #00ffff
blue  #0000ff
```

This patch adjusts table border widths to the column widths computed dynamically:

```
color code
----- -------
red   #ff0000
green #00ffff
blue  #0000ff
```

This is maybe not a big deal for simple tables, but it helps with readability for those with more columns and/or more whitespace inside:

```
$ printf 'phrase|character count\n--|--\nfoo bar|7\nshow must go on|15\neasy as pie|16\n' |msee

phrase          character count
--              --
foo bar         7
show must go on 15
easy as pie     16
```

versus

```
phrase          character count
--------------- ---------------
foo bar         7
show must go on 15
easy as pie     16
```