### PR TITLE
Fixed grey color in ubuntu

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -31,7 +31,7 @@ exports.main = function() {
             try {
                 var file = path.resolve(process.cwd(), files[0]);
                 var text = msee.parseFile(file);
-                console.log(text);
+                process.stdout.write(text);
             }
             catch (e) {
                 console.error(e.message);
@@ -44,7 +44,7 @@ exports.main = function() {
             });
             process.stdin.on('end', function() {
                 var out = msee.parse(text);
-                console.log(out);
+                process.stdout.write(out);
             });
         }
         else {

--- a/lib/color.js
+++ b/lib/color.js
@@ -1,10 +1,13 @@
 var chalk = require('chalk');
+var os = require('os');
+var lightColor = os.platform() === 'linux' ? chalk.white : chalk.grey;
+
 
 var colorBrushes = {
-    "syntax": chalk.grey,
+    "syntax": lightColor,
     "heading": chalk.cyan.bold,
-    "hr": chalk.grey,
-    "code": chalk.grey,
+    "hr": lightColor,
+    "code": lightColor,
     "blockquote": chalk.blue,
     "bold": chalk.bold,
     "link": chalk.blue,

--- a/test/fixtures/general.linux.out
+++ b/test/fixtures/general.linux.out
@@ -123,4 +123,3 @@ the     engine
 
 [36m[1m[37m## [36mCould be written in various ways[22m[39m
 
-

--- a/test/fixtures/general.linux.out
+++ b/test/fixtures/general.linux.out
@@ -1,0 +1,126 @@
+
+[36m[1m[37m# [36mHeadline 1[22m[39m
+
+This is a test document it contains a lot of text that should be wrapped to
+multiple lines.
+日本語のテキストも書いてあります。どうしてかというと漢字はコンソールで二つの半角
+のスペースを使っています。
+
+[37m-------------------------------------------------------------------------------
+[39mWe also make sure that there is inline [3mitalic[23m and [1mbold[22m text. Maybe even [3m[1mbold
+italic[22m[23m text? And how about [37mcode[39m or [1m[37mbold code[39m[22m or [3m[1m[37mbold italic code[39m[22m[23m? Maybe we need
+some [1mbold[22m statements written with [3mitalic[23m letters? or [37m**bold code**[39m that is
+processed other wise? &copy; Should become © or shouldn't it? Multiple spaces
+like here   should turn into a single space    even with a tab. To ensure a
+space we can still use &nbsp;&nbsp;, can't we?
+
+[36m[1m[37m## [36mA few ways to link[22m[39m
+
+[[1mA link somewhere[22m]([34mhttp://somewhere.to.go[39m)
+[[1mhttp://somewhere.to.go[22m]([34mhttp://somewhere.to.go[39m)
+[[1mhttp://somewhere.to.go[22m]([34mhttp://somewhere.to.go[39m) [34m<http://somewhere.to.go>[39m [[1m`A
+code link to somewhere`[22m]([34mhttp://somewhere.to.go[39m) [[1m_An italic link to
+somewhere_[22m]([34mhttp://somewhere.to.go[39m) [1m[[1mAn bold link to
+somewhere[1m]([34mhttp://somewhere.to.go[39m)[22m [link][] [link to nowhere][] [numbered
+link][1]
+
+[36m[1m[37m## [36mImages[22m[39m
+
+[[1mAn image[22m]([34m./image.jpg[39m) [[1m![A linked image](./image.jpg)[22m]([34mhttp://somewhere.to.go[39m)
+
+[36m[1m[37m## [36mRegular Lists[22m[39m
+
+Here is some perfectly normal text before a list, just to make sure that the
+spacing is good.
+
+[37m  * [39mRegular Entry [37m  * [39mwith a deep list 
+[37m  * [39mVery, very long entry with a lot of text. So much text in fact that it will
+[37m    [39musually require a line-break to contain it all. This text is also containing
+[37m    [39msome japanese characters like こんにちは and
+[37m    [39mどうもありがとうミスターロボット to check for multi-line entries
+[37m  * [39mLists should even support indented code [37m  For the fun of it[39m 
+[37m  * [39mAnother entry with a [[1mlink[22m]([34mhttp://somewhere.to.go[39m) [37m  [3m [39mDeep lists with [37m  [23m [39m[37mx[39m
+[37m    [39mor [37m  * [39mother deep lists [37m  [3m [39mwith stars should work [37m  [23m [39mfine as well 
+undefinedA list entry with follow up lines  that are indented both with spaces  and with tabs for the sake of testing.  even with multiple lines in the mix  これは問題ないでしょうか？undefined
+Same thing after the list.
+
+[37m  * [39mBut lets end with a list anyways
+[37m  * [39mTo make sure that the spacing to a header is good as well.
+
+[36m[1m[37m## [36mOrdered Lists[22m[39m
+
+Another good text before an ordered list.
+
+[37m  * [39mRegular Entry,
+[37m  * [39mVery, very long entry with a lot of text. So much text in fact that it will
+[37m    [39musually require a line-break to contain it all. This text is also containing
+[37m    [39msome japanese characters like こんにちは and
+[37m    [39mどうもありがとうミスターロボット to check for multi-line entries
+[37m  * [39mIndented Blockquotes should be fine too [34m[37m  > [34mFor the fun of itLets have a
+[37m    [39mblockquote contest[39m 
+[37m  * [39mAnother entry with a [[1mlink[22m]([34mhttp://somewhere.to.go[39m)
+[37m  * [39mWhile we are at it [37m  [3m [39mIt should be possible to have nested lists with 4
+[37m    [39mspaces too [37m  [23m [39mBut also with tabs [37m  [3m [39meven nested entries of nested entries
+[37m    [39mshouldn't break [37m    [39mthis. [37m  [23m [39mPerhaps I am naive? 
+
+Same thing after the list.
+
+[37m  * [39mAlso testing if the order of the numbering is
+[37m  * [39mOf any value or if we
+[37m  * [39mCompletely ignore them same as markdown does ...
+
+[36m[1m[37m## [36mCode[22m[39m
+
+Code should be writable inline like [37mthis[39m and even support back-ticks like
+[37mhello` world[39m but also as a block like:
+
+    [37m// &copy; 2016[39m
+    [35mfunction[39m anExamplaryJavaScriptMethod [31m([39m[31m)[39m [31m{[39m
+        [35mreturn[39m whyDoesThisLegacyObject[31m.[39mhaveAMethodThatRequiresManyArgumentsAndSuchALongTitle[31m([39mits[31m,[39m to[31m,[39m test[31m,[39m wrapping[31m,[39m of[31m,[39m code[31m)[39m
+    [31m}[39m
+
+Lets make sure that maybe some other formatting is supported as well
+
+    [37m/* Hello World program */
+    #include<stdio.h>
+    
+    int main() {
+       printf("Hello World");
+       return 0;
+    }[39m
+
+[36m[1m[37m## [36mQuotes[22m[39m
+
+[34m[37m  > [34m [36m[1m[37m# [36mYou should know this is a header[22m[34m There is also support for quotes with
+[37m  > [34m`code` and [a link](http://somewhere.to.go) and some **bold** text that
+[37m  > [34mexplodes this line totally.
+[37m  > [34m次の行目もテキストがたくさんが入っています。_どうして_
+[37m  > [34mフォマッティングがおかしくなるのをテストするからです。もしかして短いテキスト
+[37m  > [34mは問題なしに連打されているかもしれません。 [34m[37m  > [34mEven nested Quotes are fine,
+[37m  > [34marn't they[34m [37m  * [34mSometimes we have even lists in quotes [37m  * [34mSometimes long
+[37m  > [34mlists [37mCode blocks should work too! with a lot of text multiline even[34m lets
+[37m  > [34msee if all this work.[39m
+
+[36m[1m[37m## [36mTable[22m[39m
+
+[1mWe[22m      [1meven[22m                                                                                    [1msupport[22m [1mtables[22m
+------- --------------------------------------------------------------------------------------- ------- --------------------------------
+but     sadly                                                                                   only    single-line
+how     about                                                                                   [3mitalic[23m  or [1mbold[22m
+[37mtext[39m    it should be as formatted as                                                            &copy;  but [[1mbetter[22m]([34mhttp://somwhere.to[39m)
+perhaps a very long text block in the middle of this is not needlessly wrapped after some point and     maybe
+even    missing
+columns don't                                                                                   disturb
+the     engine
+
+[36m[1m[37m### [36mSome ...[22m[39m
+
+[36m[1m[37m#### [36m... More ...[22m[39m
+
+[36m[1m[37m##### [36m... Headers[22m[39m
+
+[36m[1m[37m# [36mHeaders with underlines[22m[39m
+
+[36m[1m[37m## [36mCould be written in various ways[22m[39m
+
+

--- a/test/msee.js
+++ b/test/msee.js
@@ -6,6 +6,7 @@ const os = require('os')
 
 test('default general test', function (t) {
 	var platform = os.platform() === 'linux' ? '.linux' : ''
+	console.log(platform)
 	t.equal(
 		msee.parseFile(path.join(__dirname, 'fixtures', 'general.md'), {maxWidth: 80}),
 		fs.readFileSync(path.join(__dirname, 'fixtures', 'general' + platform + '.out'), 'utf8')

--- a/test/msee.js
+++ b/test/msee.js
@@ -6,10 +6,11 @@ const os = require('os')
 
 test('default general test', function (t) {
 	var platform = os.platform() === 'linux' ? '.linux' : ''
-	console.log(platform)
+	var pth = 'general' + platform + '.out'
+	var out = fs.readFileSync(path.join(__dirname, 'fixtures', pth), 'utf8')
 	t.equal(
 		msee.parseFile(path.join(__dirname, 'fixtures', 'general.md'), {maxWidth: 80}),
-		fs.readFileSync(path.join(__dirname, 'fixtures', 'general' + platform + '.out'), 'utf8')
+		out
 	)
 	t.end()
 })

--- a/test/msee.js
+++ b/test/msee.js
@@ -2,11 +2,13 @@ const test = require('tap').test
 const msee = require('../')
 const path = require('path')
 const fs = require('fs')
+const os = require('os')
 
 test('default general test', function (t) {
+	var platform = os.platform() === 'linux' ? '.linux' : ''
 	t.equal(
 		msee.parseFile(path.join(__dirname, 'fixtures', 'general.md'), {maxWidth: 80}),
-		fs.readFileSync(path.join(__dirname, 'fixtures', 'general.out'), 'utf8')
+		fs.readFileSync(path.join(__dirname, 'fixtures', 'general' + platform + '.out'), 'utf8')
 	)
 	t.end()
 })


### PR DESCRIPTION
We have some issues in Ubuntu with solarized color scheme: https://github.com/workshopper/learnyounode/issues/381 It seems like solarized doesn't like grey so I disabled grey on linux.