### PR TITLE
Fixes failing test

### DIFF
--- a/test/fixtures/general.linux.out
+++ b/test/fixtures/general.linux.out
@@ -39,7 +39,7 @@ spacing is good.
 [37m    [39msome japanese characters like こんにちは and
 [37m    [39mどうもありがとうミスターロボット to check for multi-line entries
 [37m  * [39mLists should even support indented code [37m  For the fun of it[39m 
-[37m  * [39mAnother entry with a [[1mlink[22m]([34mhttp://somewhere.to.go[39m) [37m  [3m [39mDeep lists with [37m  [23m [39m[37mx[39m
+[37m  * [39mAnother entry with a [[1mlink[22m]([34mhttp://somewhere.to.go[39m) [37m  [3m [39mDeep lists with [37m  [23m [39m[37mx
 [37m    [39mor [37m  * [39mother deep lists [37m  [3m [39mwith stars should work [37m  [23m [39mfine as well 
 undefinedA list entry with follow up lines  that are indented both with spaces  and with tabs for the sake of testing.  even with multiple lines in the mix  これは問題ないでしょうか？undefined
 Same thing after the list.

--- a/test/fixtures/general.out
+++ b/test/fixtures/general.out
@@ -39,7 +39,7 @@ spacing is good.
 [90m    [39msome japanese characters like こんにちは and
 [90m    [39mどうもありがとうミスターロボット to check for multi-line entries
 [90m  * [39mLists should even support indented code [90m  For the fun of it[39m 
-[90m  * [39mAnother entry with a [[1mlink[22m]([34mhttp://somewhere.to.go[39m) [90m  [3m [39mDeep lists with [90m  [23m [39m[90mx[39m
+[90m  * [39mAnother entry with a [[1mlink[22m]([34mhttp://somewhere.to.go[39m) [90m  [3m [39mDeep lists with [90m  [23m [39m[90mx
 [90m    [39mor [90m  * [39mother deep lists [90m  [3m [39mwith stars should work [90m  [23m [39mfine as well 
 undefinedA list entry with follow up lines  that are indented both with spaces  and with tabs for the sake of testing.  even with multiple lines in the mix  これは問題ないでしょうか？undefined
 Same thing after the list.


### PR DESCRIPTION
This may, in fact, be a bug in wcstring.wrap() where it discards
the trailing Esc[39m when word wrapping a string that ends its line
with that escape sequence. That said, this change fixes the test
until a better solution can be found.