### PR TITLE
Fix bug where a list separated by a blank line mis-renders

### DIFF
--- a/lib/msee.js
+++ b/lib/msee.js
@@ -234,6 +234,7 @@ function processToken(options) {
 
             return options.listStart + content + options.listEnd;
         }
+        case 'loose_item_start':
         case 'list_item_start': {
             content = '';
 

--- a/test.md
+++ b/test.md
@@ -1,3 +1,5 @@
 - hi
 - ho
 - hu
+
+- hum

--- a/test/fixtures/general.linux.out
+++ b/test/fixtures/general.linux.out
@@ -41,7 +41,7 @@ spacing is good.
 [37m  * [39mLists should even support indented code [37m  For the fun of it[39m 
 [37m  * [39mAnother entry with a [[1mlink[22m]([34mhttp://somewhere.to.go[39m) [37m  [3m [39mDeep lists with [37m  [23m [39m[37mx
 [37m    [39mor [37m  * [39mother deep lists [37m  [3m [39mwith stars should work [37m  [23m [39mfine as well 
-[37m  * [39mA list entry with follow up lines  that are indented both with spaces  and
+[37m  * [39mA list entry with follow up lines  that are indented both with spaces  and
 [37m    [39mwith tabs for the sake of testing.  even with multiple lines in the mix
 [37m    [39mこれは問題ないでしょうか？
 

--- a/test/fixtures/general.linux.out
+++ b/test/fixtures/general.linux.out
@@ -41,7 +41,10 @@ spacing is good.
 [37m  * [39mLists should even support indented code [37m  For the fun of it[39m 
 [37m  * [39mAnother entry with a [[1mlink[22m]([34mhttp://somewhere.to.go[39m) [37m  [3m [39mDeep lists with [37m  [23m [39m[37mx
 [37m    [39mor [37m  * [39mother deep lists [37m  [3m [39mwith stars should work [37m  [23m [39mfine as well 
-undefinedA list entry with follow up lines  that are indented both with spaces  and with tabs for the sake of testing.  even with multiple lines in the mix  これは問題ないでしょうか？undefined
+[37m  * [39mA list entry with follow up lines  that are indented both with spaces  and
+[37m    [39mwith tabs for the sake of testing.  even with multiple lines in the mix
+[37m    [39mこれは問題ないでしょうか？
+
 Same thing after the list.
 
 [37m  * [39mBut lets end with a list anyways

--- a/test/fixtures/general.out
+++ b/test/fixtures/general.out
@@ -41,7 +41,10 @@ spacing is good.
 [90m  * [39mLists should even support indented code [90m  For the fun of it[39m 
 [90m  * [39mAnother entry with a [[1mlink[22m]([34mhttp://somewhere.to.go[39m) [90m  [3m [39mDeep lists with [90m  [23m [39m[90mx
 [90m    [39mor [90m  * [39mother deep lists [90m  [3m [39mwith stars should work [90m  [23m [39mfine as well 
-undefinedA list entry with follow up lines  that are indented both with spaces  and with tabs for the sake of testing.  even with multiple lines in the mix  これは問題ないでしょうか？undefined
+[90m  * [39mA list entry with follow up lines  that are indented both with spaces  and
+[90m    [39mwith tabs for the sake of testing.  even with multiple lines in the mix
+[90m    [39mこれは問題ないでしょうか？
+
 Same thing after the list.
 
 [90m  * [39mBut lets end with a list anyways


### PR DESCRIPTION
This happens when marked generates a token of type 'loose_item_start'
instead of 'list_item_start'. Both list item types are terminated by
'list_item_end' so we treat loose and list items as equivalent.